### PR TITLE
Missing license headers

### DIFF
--- a/public/browser_error.html
+++ b/public/browser_error.html
@@ -1,3 +1,25 @@
+<!--
+ Copyright 2017 Telefónica Digital España S.L.
+ 
+ This file is part of UrboCore WWW.
+ 
+ UrboCore WWW is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Affero General Public License as
+ published by the Free Software Foundation, either version 3 of the
+ License, or (at your option) any later version.
+ 
+ UrboCore WWW is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ General Public License for more details.
+ 
+ You should have received a copy of the GNU Affero General Public License
+ along with UrboCore WWW. If not, see http://www.gnu.org/licenses/.
+ 
+ For those usages not covered by this license please contact with
+ iot_support at tid dot es
+-->
+
 <!doctype html>
 <head><title>Telefónica Smart City</title></head>
 <body style="background-color:#eee">

--- a/public/embed.html
+++ b/public/embed.html
@@ -1,3 +1,24 @@
+<!--
+ Copyright 2018 Telefónica Digital España S.L.
+ 
+ This file is part of UrboCore WWW.
+ 
+ UrboCore WWW is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Affero General Public License as
+ published by the Free Software Foundation, either version 3 of the
+ License, or (at your option) any later version.
+ 
+ UrboCore WWW is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+ General Public License for more details.
+ 
+ You should have received a copy of the GNU Affero General Public License
+ along with UrboCore WWW. If not, see http://www.gnu.org/licenses/.
+ 
+ For those usages not covered by this license please contact with
+ iot_support at tid dot es
+-->
 
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
Missing heders in a couple of .html files. They pass unnoticed until now due to a bug in the checking script.

We decided not to include headers in template files but, as far as I understand, browser_error.html and embed.html are not such templates and this modification make sense. Please tell me if I'm wrong.