### PR TITLE
Javiguisado/ch41455/incendios qa cliente

### DIFF
--- a/deps.js
+++ b/deps.js
@@ -41,8 +41,8 @@ deps.JS = [
   srcJS + 'App.js',
 
   // Utils
-  //srcJS + 'Utils.js@finish-main-block',
-  srcJS + 'Utils.js',
+  srcJS + 'Utils.js@finish-main-block',
+  //srcJS + 'Utils.js',
 
   // Views
   srcJS + 'View/BaseView.js',

--- a/deps.js
+++ b/deps.js
@@ -41,8 +41,8 @@ deps.JS = [
   srcJS + 'App.js',
 
   // Utils
-  srcJS + 'Utils.js@finish-main-block',
-  //srcJS + 'Utils.js',
+  //srcJS + 'Utils.js@finish-main-block',
+  srcJS + 'Utils.js',
 
   // Views
   srcJS + 'View/BaseView.js',

--- a/src/css/devices/device_list.less
+++ b/src/css/devices/device_list.less
@@ -22,7 +22,8 @@
 	position: absolute;
 	z-index: 4;
 	background-color: #fff;
-	width: 360px;
+	width: auto;
+	min-width:360px;
 	border: 1px solid #ccccce;
 	box-shadow: 2px 0px 10px 0px rgba(0,0,0,0.15);
 	opacity: 0;

--- a/src/js/View/DashboardView.deprecated.js
+++ b/src/js/View/DashboardView.deprecated.js
@@ -143,13 +143,13 @@ App.View.Dashboard = Backbone.View.extend({
         [
           {
             id:'master',
-            title: __('Estado general'),
+            title: __('Estado General'),
             url:scope + '/watering/dashboard',
             selected:true
           },
           {
             id:'mapdevices',
-            title: __('Mapa de dispositivos'),
+            title: __('Tiempo Real'),
             url:scope + '/watering/map'
           },
           {
@@ -200,15 +200,17 @@ App.View.Dashboard = Backbone.View.extend({
         color: '#00d5e7',
         timeMode:'now'
       });
+      
       this._widgets.push(new App.View.WidgetDeviceMap({model: m}));
 
       this._widgets.push(new App.View.Widgets.Watering.Operation({
         id_scope:this.scopeModel.get('id'),
       }));
 
-      this._widgets.push(new App.View.Widgets.Watering.Consumption({
-        id_scope: this.scopeModel.get('id')
-      }));
+      //For some reason when this widget loads all graphs get corrupted
+      // this._widgets.push(new App.View.Widgets.Watering.Consumption({
+      //   id_scope: this.scopeModel.get('id')
+      // }));
 
       // var wasteLinkModel = new Backbone.Model({
       //   'title': 'Análisis de variables',

--- a/src/js/View/DashboardView.deprecated.js
+++ b/src/js/View/DashboardView.deprecated.js
@@ -208,9 +208,9 @@ App.View.Dashboard = Backbone.View.extend({
       }));
 
       //For some reason when this widget loads all graphs get corrupted
-      // this._widgets.push(new App.View.Widgets.Watering.Consumption({
-      //   id_scope: this.scopeModel.get('id')
-      // }));
+      this._widgets.push(new App.View.Widgets.Watering.Consumption({
+        id_scope: this.scopeModel.get('id')
+      }));
 
       // var wasteLinkModel = new Backbone.Model({
       //   'title': 'Análisis de variables',

--- a/src/js/View/Map/Layer/MapboxSQLLayer.js
+++ b/src/js/View/Map/Layer/MapboxSQLLayer.js
@@ -45,7 +45,7 @@ App.View.Map.Layer.MapboxSQLLayer = App.View.Map.Layer.MapboxGLVectorLayer.exten
       var cartoLayer = response;
       var nStyle = this._map._map.getStyle();
 
-      if (nStyle.sources[this._idSource]) {
+      if (nStyle && nStyle.sources && nStyle.sources[this._idSource]) {
         nStyle.sources[this._idSource].tiles = cartoLayer.metadata.tilejson.vector.tiles;
         this._map._map.setStyle(nStyle);  
       }

--- a/src/js/View/widgets/WidgetDeviceMapView.js
+++ b/src/js/View/widgets/WidgetDeviceMapView.js
@@ -37,7 +37,7 @@ App.View.WidgetDeviceMap = App.View.Widgets.Base.extend({
     // Default values
     var defaultValues = {
       link: '/' + this.model.get('scope') + '/' + this.model.get('section') + '/map',
-      title: __('Mapa de dispositivos'),
+      title: __('Tiempo Real'),
       titleLink: null
     };
 

--- a/src/js/View/widgets/WidgetWrapperBase.js
+++ b/src/js/View/widgets/WidgetWrapperBase.js
@@ -27,11 +27,16 @@ App.View.Widgets.WidgetWrapperBase = App.View.Widgets.Base.extend({
 
   initialize: function(options) {
     options = _.defaults(options, {
-      title: __('Sin título')
+      title: __('Sin título'),
+      stopEventsBbox: false,
     });
 
     // Call to parent class
     App.View.Widgets.Base.prototype.initialize.call(this, options);
+
+    if(options.stopEventsBbox){
+      this.stopListening(App.ctx, 'change:bbox')
+    }
 
     // Skip more code if widget is not allowed
     if(!this.hasPermissions()) return;


### PR DESCRIPTION
Lista d cambios
- La lista de dispositivos (con o sin filtrado) escala su tamaño si los nombres de los dispositivos que alberga no caben en el tamaño por defecto (360px)
- Generalizacion de nombres, Estado General y Tiempo Real para watering
- Había un error puntual, en principio no afectaba a la web pero si salía en ocasiones en la consola, en MapboxSQLLayer.js, cuando nStyle es undefined
- Añadida la posibilidad de crear WidgetWrapperBase anulando los listeners de la vista de la que hereda (Widgets.base)