### PR TITLE
- Now the datepicker has "minDate" and "maxDate" values to set the dates

### DIFF
--- a/src/js/View/DateView.js
+++ b/src/js/View/DateView.js
@@ -20,69 +20,82 @@
 
 'use strict';
 
-$.datepicker.regional['es'] =
-    {
-        "monthNames": [
-          "Enero",
-          "Febrero",
-          "Marzo",
-          "Abril",
-          "Mayo",
-          "Junio",
-          "Julio",
-          "Agosto",
-          "Septiembre",
-          "Octubre",
-          "Noviembre",
-          "Diciembre"
-        ],
-
-        "dayNames": [
-          "Domingo",
-          "Lunes",
-          "Martes",
-          "Miércoles",
-          "Jueves",
-          "Viernes",
-          "Sábado"
-        ],
-        "dayNamesShort": [
-          "D",
-          "L",
-          "M",
-          "X",
-          "J",
-          "V",
-          "S"
-        ],
-        "dayNamesMin": [
-          "D",
-          "L",
-          "M",
-          "X",
-          "J",
-          "V",
-          "S"
-        ],
-      }
-    ;
-    $.datepicker.setDefaults($.datepicker.regional['es']);
-
+// defaults values for every datepicker
+$.datepicker.regional['es'] = {
+  monthNames: [
+    'Enero',
+    'Febrero',
+    'Marzo',
+    'Abril',
+    'Mayo',
+    'Junio',
+    'Julio',
+    'Agosto',
+    'Septiembre',
+    'Octubre',
+    'Noviembre',
+    'Diciembre'
+  ],
+  dayNames: [
+    'Domingo',
+    'Lunes',
+    'Martes',
+    'Miércoles',
+    'Jueves',
+    'Viernes',
+    'Sábado'
+  ],
+  dayNamesShort: [
+    'D',
+    'L',
+    'M',
+    'X',
+    'J',
+    'V',
+    'S'
+  ],
+  dayNamesMin: [
+    'D',
+    'L',
+    'M',
+    'X',
+    'J',
+    'V',
+    'S'
+  ],
+};
+$.datepicker.setDefaults($.datepicker.regional['es']);
 
 App.View.Date = Backbone.View.extend({
-  _template: _.template( $('#date_template').html() ),
 
-  initialize: function(options) {
-    var options = options || {};
-    this._compact = options.compact ? options.compact : null;
-    this.model = options.model ? options.model : App.ctx;
-    this.maxRange = options.maxRange ? options.maxRange : moment.duration(1, 'year');
-    this.listenTo(this.model,'change:start change:finish',this._renderDatePicker);
+  _template: _.template($('#date_template').html()),
+
+  initialize: function (options) {
+    // default options
+    options = _.defaults(options || {}, {
+      dateFormat: 'dd/mm/yy',
+      compact: null,
+      model: App.ctx, //context dates
+      maxRange: moment.duration(1, 'year'),
+      minDate: null,
+      maxDate: null
+    });
+
+    // To use in other View parts
+    this.options = options;
+
+    this._setMinAndMaxDatesToModel();
+
+    // Events - Change dates model (App.ctx)
+    this.listenTo(this.options.model, 'change:start change:finish', this._setValuesInDatePickers);
+    // Events - Change date limits
+    this.on('change:minDate change:maxDate', this._setMinAndMaxDatesToModel, this);
+
     _.bindAll(this, '_placeDatePicker');
   },
 
   events: {
-    'mouseup .date' : '_datepickerPosition',
+    'mouseup .date': '_datepickerPosition',
     'click .range_selector': '_toggleRangeValues',
     'click .range_values li': '_rangeSelected',
     'change .date.start, .date.finish': '_dateChange',
@@ -90,74 +103,143 @@ App.View.Date = Backbone.View.extend({
     'mouseleave': '_addCompact'
   },
 
-  onClose: function () {
-    this.stopListening();
-  },
-
   render: function () {
-    var _this = this;
     var isHighRangeCtx = false;
     var isCrazyRangeCtx = false;
-    if (this.maxRange.asDays() >= 365 && this.maxRange.asDays < 36500) {
+    var datepickerOptions = {
+      dateFormat: this.options.dateFormat,
+      beforeShow: this._placeDatePicker,
+      onClose: function () {
+        this._close_datepicker();
+      }.bind(this)
+    };
+
+    if (this.options.maxRange.asDays() >= 365 && this.options.maxRange.asDays() < 36500) {
       isHighRangeCtx = true;
-    } else if(this.maxRange.asDays() >= 36500) {
+    } else if (this.options.maxRange.asDays() >= 36500) {
       isHighRangeCtx = true;
       isCrazyRangeCtx = true;
     }
-    this.setElement(this._template({ isHighRangeCtx: isHighRangeCtx, isCrazyRangeCtx: isCrazyRangeCtx }));
-    this.$('.date').datepicker({ dateFormat: 'dd/mm/yy',
-      beforeShow: this._placeDatePicker,
-      onClose: function () {
-        _this._close_datepicker();
-      }
-    });
 
-    this._renderDatePicker();
+    // Draw the template in DOM
+    this.setElement(
+      this._template({
+        isHighRangeCtx: isHighRangeCtx,
+        isCrazyRangeCtx: isCrazyRangeCtx
+      })
+    );
+    
+    // Initialize the jQuery datepicker
+    this.$('.date').datepicker(datepickerOptions);
 
-    if (this._compact)
+    this._setValuesInDatePickers();
+
+    if (this.options.compact) {
       this.$el.addClass('compact');
+    }
 
     return this;
   },
 
-  _renderDatePicker: function () {
+  /**
+   * Event triggered when the parámeters "options.minDate"
+   * and "options.maxDate" are changed
+   */
+  _setMinAndMaxDatesToModel: function () {
+    if (this.options.minDate instanceof Date) {
+      if (moment(this.options.minDate).isAfter(this.options.model.get('start'))) {
+        this.options.model.set('start', moment(this.options.minDate));
+      }
+    }
+
+    if (this.options.maxDate instanceof Date) {
+      if (moment(this.options.maxDate).isBefore(this.options.model.get('finish'))) {
+        this.options.model.set('finish', moment(this.options.maxDate));
+      }
+      this.options.model.set('finish', moment(this.options.maxDate));
+    }
+  },
+
+  /**
+   * Put the values object ctx (dates) inside the different inputs (datepickers)
+   */
+  _setValuesInDatePickers: function () {
+    // Check if the date is inside the "min" and "max"
+    var dateStart = this.options.minDate === null 
+      || moment(this.options.minDate).isAfter(this.options.model.get('start'))
+        ? this.options.model.get('start').toDate()
+        : this.options.minDate;
+    var dateFinish = this.options.maxDate === null
+      || moment(this.options.maxDate).isBefore(this.options.model.get('finish'))
+        ? this.options.model.get('finish').toDate()
+        : this.options.maxDate;
+
     try {
-      this.$('.date.start').datepicker('setDate', this.model.get('start').toDate());
-      this.$('.date.finish').datepicker('setDate', this.model.get('finish').toDate());
+      this.$('.date.start').datepicker('setDate', dateStart);
+      this.$('.date.finish').datepicker('setDate', dateFinish);
     } catch (err) {
       this.$('.date.start').val('--').datepicker();
       this.$('.date.finish').val('--').datepicker();
     }
   },
 
-  _placeDatePicker: function(input, inst){
-    if(input.classList.contains('start')){
-      var lastDate = moment(this.$('.date.finish').datepicker('getDate')).startOf('day');
-      var firstDate = lastDate.clone().subtract(this.maxRange);
+  /**
+   * In triggered in the event "beforeShow" from the datepicker
+   * 
+   * Set varios options inside the different "datepicker" instances
+   * 
+   * @param {Object} input - datepicker input
+   * @param {Object} inst - datepicker instance
+   */
+  _placeDatePicker: function (input, inst) {
+    if (input.classList.contains('start')) {
+      // Check the "min" and "max" date
+      var lastDate = this.options.maxDate === null
+        || moment(this.options.maxDate).isBefore(this.$('.date.finish').datepicker('getDate'))
+          ? moment(this.$('.date.finish').datepicker('getDate')).startOf('day')
+          : moment(this.options.maxDate).startOf('day');
+      var lastDateMinusRange = lastDate.clone().subtract(this.options.maxRange);
+      var firstDate = this.options.minDate === null
+        || moment(this.options.minDate).isBefore(lastDateMinusRange)
+          ? lastDateMinusRange
+          : moment(this.options.minDate);
+
+      // var lastDate = moment(this.$('.date.finish').datepicker('getDate')).startOf('day');
+      // var firstDate = lastDate.clone().subtract(this.options.maxRange);
       inst.settings.minDate = firstDate.toDate();
       inst.settings.maxDate = lastDate.toDate();
-    }else if (input.classList.contains('finish')){
-      var firstDate = moment(this.$('.date.start').datepicker('getDate')).startOf('day');
-      var lastDate = firstDate.clone().add(this.maxRange);
+    } else if (input.classList.contains('finish')) {
+      var firstDate = this.options.minDate === null
+        || moment(this.options.minDate).isAfter(moment(this.$('.date.start').datepicker('getDate')))
+          ? moment(this.$('.date.start').datepicker('getDate')).startOf('day')
+          : moment(this.options.minDate).startOf('day');
+      var firstDateAddRange = firstDate.clone().add(this.options.maxRange);
+      var lastDate = this.options.maxDate === null
+        || moment(this.options.maxDate).isAfter(firstDateAddRange)
+          ? firstDateAddRange
+          : moment(this.options.maxDate);
+
+      // var firstDate = moment(this.$('.date.start').datepicker('getDate')).startOf('day');
+      // var lastDate = firstDate.clone().add(this.options.maxRange);
       inst.settings.minDate = firstDate.toDate();
       inst.settings.maxDate = lastDate.toDate();
-    }else{
+    } else {
       return -1;
     }
     this.$el.append(inst.dpDiv);
   },
 
-  _datepickerPosition:function(e){
+  _datepickerPosition: function (e) {
     this.$el.removeClass('range_open');
-    $('#ui-datepicker-div').css({'left':this.$el.css('left')});
+    $('#ui-datepicker-div').css({ 'left': this.$el.css('left') });
     $(e.currentTarget).closest('.date_wrapper').addClass('active');
     this.$('.header').addClass('picker_open');
 
     this.$el.addClass('all_height')
   },
 
-  _close_datepicker:function(){
-    $('#ui-datepicker-div').css({'display':'none'});
+  _close_datepicker: function () {
+    $('#ui-datepicker-div').css({ 'display': 'none' });
     this.$('.picker_open').removeClass('picker_open');
     this.$('.date_wrapper').removeClass('active');
     this.$('.date').datepicker('hide');
@@ -168,58 +250,104 @@ App.View.Date = Backbone.View.extend({
     this.$el.removeClass('all_height')
   },
 
-  _toggleRangeValues:function(e){
+  _toggleRangeValues: function (e) {
     this._close_datepicker()
     this.$el.toggleClass('range_open');
   },
 
-  _rangeSelected:function(e){
+  /**
+   * Event triggered when the user change (click)
+   * the date range (Today, last month...)
+   */
+  _rangeSelected: function (e) {
     e.stopPropagation();
     this.$el.removeClass('range_open');
 
     var finish = moment().endOf('day');
-    
     var start;
     var $e = $(e.currentTarget),
       unit = $e.attr('data-unit'),
       value = parseInt($e.attr('data-value'));
-    
+
     if (unit !== 'origin') {
-      start = moment().subtract(value,unit).startOf('day')
+      start = moment().subtract(value, unit).startOf('day')
     } else {
       start = moment(0).startOf('day');
     }
 
-    this.model.set({
+    this.options.model.set({
       start: start.utc(),
-      finish:finish.utc()
+      finish: finish.utc()
     });
 
     this._addCompact();
   },
 
-  _dateChange:function(){
-    var start = moment(this.$('.date.start').datepicker('getDate')).startOf('day'),
-      finish = moment(this.$('.date.finish').datepicker('getDate')).endOf('day');
+  /**
+   * Event triggered when the user change the date
+   * or select (click) other date from datepicker
+   */
+  _dateChange: function () {
+    var currentStartDatePicker = moment(this.$('.date.start').datepicker('getDate'));
+    var currentFinishDatePicker = moment(this.$('.date.finish').datepicker('getDate'));
+    // Check if the date is inside the "min" and "max"
+    var start = this.options.minDate === null
+      || moment(this.options.minDate).isAfter(currentStartDatePicker)
+        ? currentStartDatePicker
+        : moment(this.options.minDate);
+    var finish = this.options.maxDate === null
+      || moment(this.options.maxDate).isBefore(currentFinishDatePicker)
+        ? currentFinishDatePicker
+        : moment(this.options.maxDate);
+
+    // Set current (valid) Date
+    this.$('.date.start').datepicker('setDate', start.toDate());
+    this.$('.date.finish').datepicker('setDate', finish.toDate());
+
     var diffTime = finish.diff(start, 'days');
-    if(diffTime <= this.maxRange.asDays()){
-      this.model.set('start',start.utc());
-      this.model.set('finish',finish.utc());
-    }else{
-      this.model.set('start',start.utc());
-      this.model.set('finish',start.clone().add(this.maxRange).utc());
+
+    if (diffTime <= this.options.maxRange.asDays()) {
+      this.options.model.set('start', start.utc());
+      this.options.model.set('finish', finish.utc());
+    } else {
+      this.options.model.set('start', start.utc());
+      this.options.model.set('finish', start.clone().add(this.options.maxRange).utc());
     }
   },
 
-  _removeCompact:function(){
+  /**
+   * Close datepicker dialog
+   */
+  _removeCompact: function () {
     this.$el.removeClass('compact');
   },
 
-  _addCompact:function(){
-    if(this._compact){
+  /**
+   * Open datepicker dialog
+   */
+  _addCompact: function () {
+    if (this.options.compact) {
       this.$el.addClass('compact');
       this.$el.removeClass('range_open');
     }
+  },
+
+  /**
+   * Set options to datepicker
+   * 
+   * @param {String} key - option key
+   * @param {String | Object | Number} value - value key
+   */
+  _setOptions: function (key, value) {
+    this.options[key] = value;
+    this.trigger('change:' + key);
+  },
+  
+  /**
+   * Triggered when the View is remove from DOM
+   */
+  onClose: function () {
+    this.stopListening();
   }
 
 });

--- a/src/js/View/DateView.js
+++ b/src/js/View/DateView.js
@@ -166,11 +166,11 @@ App.View.Date = Backbone.View.extend({
   _setValuesInDatePickers: function () {
     // Check if the date is inside the "min" and "max"
     var dateStart = this.options.minDate === null 
-      || moment(this.options.minDate).isAfter(this.options.model.get('start'))
+      || moment(this.options.minDate).isBefore(this.options.model.get('start'))
         ? this.options.model.get('start').toDate()
         : this.options.minDate;
     var dateFinish = this.options.maxDate === null
-      || moment(this.options.maxDate).isBefore(this.options.model.get('finish'))
+      || moment(this.options.maxDate).isAfter(this.options.model.get('finish'))
         ? this.options.model.get('finish').toDate()
         : this.options.maxDate;
 
@@ -292,11 +292,11 @@ App.View.Date = Backbone.View.extend({
     var currentFinishDatePicker = moment(this.$('.date.finish').datepicker('getDate'));
     // Check if the date is inside the "min" and "max"
     var start = this.options.minDate === null
-      || moment(this.options.minDate).isAfter(currentStartDatePicker)
+      || moment(currentStartDatePicker).isAfter(this.options.minDate)
         ? currentStartDatePicker
         : moment(this.options.minDate);
     var finish = this.options.maxDate === null
-      || moment(this.options.maxDate).isBefore(currentFinishDatePicker)
+      || moment(currentFinishDatePicker).isBefore(this.options.maxDate)
         ? currentFinishDatePicker
         : moment(this.options.maxDate);
 

--- a/src/js/template/date_template.html
+++ b/src/js/template/date_template.html
@@ -1,37 +1,36 @@
 <div id="dateSelector">
-	<div class="header">
-		<button class="range_selector">
-		</button>
-		<div class="date_wrapper">
-			<span><%= __('Desde') %></span>
-			<input type="text" class="date start">
-		</div>
-		<div class="date_wrapper">
-			<span><%= __('hasta') %></span>
-			<input type="text" class="date finish">
-		</div>
-	</div>
-	<div class="range_values">
-		<h3><%= __('Rango predefinidos') %></h3>
-		<ul>
-			<!-- <li days="-1"><%= __('Ayer') %></li> -->
-			<% if (!isHighRangeCtx && !isCrazyRangeCtx) { %>
-				<li data-unit="days" data-value="0"><%= __('Hoy') %></li>
-  			<li data-unit="days" data-value="2"><%= __('Últimos 3 días') %></li>
-  			<li data-unit="days" data-value="6"><%= __('Últimos 7 días') %></li>
-  			<li data-unit="months" data-value="1"><%= __('Último mes') %></li>
-			<% } else if(!isCrazyRangeCtx) { %>
-				<li data-unit="days" data-value="0"><%= __('Hoy') %></li>			
-        <li data-unit="months" data-value="1"><%= __('Último mes') %></li>
-        <li data-unit="months" data-value="3"><%= __('Últimos 3 meses') %></li>
-  			<li data-unit="years" data-value="1"><%= __('Último año') %></li>
-			<% } else { %>
-				<li data-unit="days" data-value="6"><%= __('Últimos 7 días') %></li>
-				<li data-unit="months" data-value="1"><%= __('Último mes') %></li>
-        <li data-unit="months" data-value="3"><%= __('Últimos 3 meses') %></li>
-				<li data-unit="years" data-value="1"><%= __('Último año') %></li>
-  			<li data-unit="origin"><%= __('Todas') %></li>				
-			<% } %>
-		</ul>
-	</div>
+  <div class="header">
+    <button class="range_selector">
+    </button>
+    <div class="date_wrapper">
+      <span><%= __('Desde') %></span>
+      <input type="text" class="date start">
+    </div>
+    <div class="date_wrapper">
+      <span><%= __('hasta') %></span>
+      <input type="text" class="date finish">
+    </div>
+  </div>
+  <div class="range_values">
+    <h3><%= __('Rango predefinidos') %></h3>
+    <ul>
+      <% if (!isHighRangeCtx && !isCrazyRangeCtx) { %>
+      <li data-unit="days" data-value="0"><%= __('Hoy') %></li>
+      <li data-unit="days" data-value="2"><%= __('Últimos 3 días') %></li>
+      <li data-unit="days" data-value="6"><%= __('Últimos 7 días') %></li>
+      <li data-unit="months" data-value="1"><%= __('Último mes') %></li>
+      <% } else if(!isCrazyRangeCtx) { %>
+      <li data-unit="days" data-value="0"><%= __('Hoy') %></li>
+      <li data-unit="months" data-value="1"><%= __('Último mes') %></li>
+      <li data-unit="months" data-value="3"><%= __('Últimos 3 meses') %></li>
+      <li data-unit="years" data-value="1"><%= __('Último año') %></li>
+      <% } else { %>
+      <li data-unit="days" data-value="6"><%= __('Últimos 7 días') %></li>
+      <li data-unit="months" data-value="1"><%= __('Último mes') %></li>
+      <li data-unit="months" data-value="3"><%= __('Últimos 3 meses') %></li>
+      <li data-unit="years" data-value="1"><%= __('Último año') %></li>
+      <li data-unit="origin"><%= __('Todas') %></li>
+      <% } %>
+    </ul>
+  </div>
 </div>


### PR DESCRIPTION
- Ahora la vista de selección de fechas admite un rango de valores "mínimo" y "máximo" de fechas.
- Para incluirlo desde la inicialización de la vista (DateView) solo hay que incluir los parámetros desde la construcción de este:
`
this.dateView = new App.View.Date({
    minDate: new Date(2019, 4, 1),
    maxDate: new Date(2019, 4, 31)
});
`

- Si deseamos modificar los límites una vez la vista ya ha sido iniciada lo haremos de la siguiente manera:

`
this.dateView._setOptions('minDate', new Date(2019, 4, 1));
this.dateView._setOptions('maxDate', new Date(2019, 4, 31));
`
- Hay que tener en cuenta que si la vista del datepicker es compartida en varias páginas o secciones como por ejemplo las pestañas de la vista del dispositivo, la limitación existirá para todas las pestañas por igual, si deseamos que la limitación solo exista en una de ellas y en otras no debemos devolver el valor de estos parámetros a NULL para que la limitación desaparezca, tal que así:

`
this.dateView._setOptions('minDate',  null);
this.dateView._setOptions('maxDate', null);
`
