### PR TITLE
Javiguisado/ef hidrica raw table unification

### DIFF
--- a/src/css/devices/device_list.less
+++ b/src/css/devices/device_list.less
@@ -42,7 +42,7 @@
 			border-bottom: 1px solid #eeeeee;
 			position: relative;
 			transition: background-color .25s;
-
+			padding-right: 15px;
 			a{
 				display: block;
 				padding: 0 14px;

--- a/src/css/devices/devices.less
+++ b/src/css/devices/devices.less
@@ -278,6 +278,26 @@
     .data_panel {
       padding-top: 20px;
     }
+    .widget{
+      &.custom-device-raw-table{
+        display:block !important;
+        height: auto !important;
+        border: 1px solid #dddddf !important;
+        padding:10px 15px;
+        .widget_header{
+          width:auto !important;
+        }
+        .date_tooltip{
+          display:none;
+        }
+        #top-scroll-bar{
+          margin-bottom: 7px;
+        }
+        .scrollable{
+          overflow-x:auto;
+        }
+      }
+    }
   }
 
   .block{

--- a/src/css/widgets/table.less
+++ b/src/css/widgets/table.less
@@ -315,6 +315,6 @@
 #top-scroll-bar {
   overflow-x: auto;
   > div{
-    height: 20px;
+    height: 2px;
   }
 }

--- a/src/js/Collection/DeviceCollection.js
+++ b/src/js/Collection/DeviceCollection.js
@@ -247,6 +247,10 @@ App.Collection.DeviceRaw = App.Collection.Post.extend({
       data: {}
     });
 
+    if (typeof options.data === 'string'){
+      options.data = JSON.parse(options.data)  
+    }
+
     // Options "format"
     if (typeof options.data.format === 'undefined' && this.options.format) {
       options.data.format = this.options.format;

--- a/src/js/View/widgets/Device/WidgetDeviceTable.js
+++ b/src/js/View/widgets/Device/WidgetDeviceTable.js
@@ -66,7 +66,7 @@ App.View.Widgets.Device.DeviceRawTable = Backbone.View.extend({
         // default options
         {
           title: '',
-          downloadButton: false,
+          downloadButton: true,
           class: 'device',
           columns: columns,
           scrollTopBar: false

--- a/src/js/View/widgets/WidgetTablePaginatedView.js
+++ b/src/js/View/widgets/WidgetTablePaginatedView.js
@@ -26,7 +26,7 @@ App.View.Widgets.TablePaginated = App.View.Widgets.Deprecated.Table.extend({
   
   events: {
     'click .showMore': 'loadMore',
-    'click .table button.downloadButton': '_downloadCsv',
+    'click button.downloadButton': '_downloadCsv',
     'scroll': 'scrollHandler'
   },
 
@@ -35,11 +35,12 @@ App.View.Widgets.TablePaginated = App.View.Widgets.Deprecated.Table.extend({
   },
 
   initialize: function (options) {
-    App.View.Widgets.Deprecated.Table.prototype.initialize.call(this, options);
-    
     if (options.template) {
       this._template = _.template(options.template);
     }
+    
+    App.View.Widgets.Deprecated.Table.prototype.initialize.call(this, options);
+  
   },
 
   render: function () {

--- a/src/js/template/base_table_template.html
+++ b/src/js/template/base_table_template.html
@@ -1,48 +1,55 @@
 <div class="table <%=m.get('css_class')%>">
   <!-- Download button CSV -->
-  <% if (m.get('csv')) { %>
+  <% if ( m.get('csv') ) { %>
   <button class="button empty up">
     <%= __('Descargar CSV') %>
   </button>
   <% } %>
   <!-- Table -->
-  <table>
-    <tbody>
-      <tr>
-      <!--  Headers -->
-      <%
-        var formats = m.get('columns_format');
-        _.each(formats,function(c,i){
-      %>
-        <th class="<%= c.css_class %>">
-          <%= (typeof c.title === 'function') ? c.title() : c.title %>
-        </th>
-      <% }) %>
-      </tr>
-      <!-- No data -->
-      <% if (!elements.length) { %>
-      <tr>
-        <td class="noDataMsg" colspan="<%= Object.keys(formats).length %>">
-          <span>No hay datos</span>
-        </td>
-      </tr>
-      <% } %>
-      <!-- Table data -->
-      <% _.each(elements,function(el){ %>
-      <tr>
-        <% _.each(formats, function (c,i) {
-          var tooltip =  c.tooltip? el[i] : '';
-        %>
-        <td <%= tooltip ? 'title="' + el[i] + '"':'' %>
-            class="<%= typeof c.css_class === 'function' ? c.css_class(el) : c.css_class %>">
-          <%= c.formatFN ? c.formatFN(el[i], el) : el[i] %>
-        </td>
-        <% }) %>
-      </tr>
-      <% }) %>
-      <!-- End data -->
-    </tbody>
-  </table>
+  <% if ( m.get('scrollTopBar') ){ %>
+    <div id="top-scroll-bar">
+      <div></div>
+    </div>
+  <% } %>
+  <div class="<%= m.get('scrollTopBar') ? 'scrollable' : '' %>">
+    <table>
+        <tbody>
+          <tr>
+          <!--  Headers -->
+          <%
+            var formats = m.get('columns_format');
+            _.each(formats,function(c,i){
+          %>
+            <th class="<%= c.css_class %>">
+              <%= (typeof c.title === 'function') ? c.title() : c.title %>
+            </th>
+          <% }) %>
+          </tr>
+          <!-- No data -->
+          <% if (!elements.length) { %>
+          <tr>
+            <td class="noDataMsg" colspan="<%= Object.keys(formats).length %>">
+              <span>No hay datos</span>
+            </td>
+          </tr>
+          <% } %>
+          <!-- Table data -->
+          <% _.each(elements,function(el){ %>
+          <tr>
+            <% _.each(formats, function (c,i) {
+              var tooltip =  c.tooltip? el[i] : '';
+            %>
+            <td <%= tooltip ? 'title="' + el[i] + '"':'' %>
+                class="<%= typeof c.css_class === 'function' ? c.css_class(el) : c.css_class %>">
+              <%= c.formatFN ? c.formatFN(el[i], el) : el[i] %>
+            </td>
+            <% }) %>
+          </tr>
+          <% }) %>
+          <!-- End data -->
+        </tbody>
+      </table>
+  </div>
   <!-- Legend -->
   <% if (m.get('legend')) { %>
   <%= m.get('legend') %>

--- a/src/js/template/devices/widget_table_raw_template.html
+++ b/src/js/template/devices/widget_table_raw_template.html
@@ -13,7 +13,7 @@
 <% } %>
 <!-- Download button -->
 <% if (m.get('downloadButton')) { %>
-<button class="button empty">
+<button class="downloadButton button empty">
   <%= __('Descargar CSV') %>
 </button>
 <% } %>

--- a/src/js/template/widgets/widget_table_paginated_template.html
+++ b/src/js/template/widgets/widget_table_paginated_template.html
@@ -3,7 +3,7 @@
     <h3><%=m.get('title')%></h3>
     <h4>(<%= __('datos desde') %> <span><%=App.formatDate(App.ctx.getDateRange().start)%></span> <%= __('hasta') %> <span><%=App.formatDate(App.ctx.getDateRange().finish)%></span>)</h4>
   <%}%>
-  <button class="button empty"><%= __('Descargar CSV') %></button>
+  <button class="downloadButton button empty"><%= __('Descargar CSV') %></button>
     <table>
       <tbody>
           <tr>


### PR DESCRIPTION
Se han realizado los siguientes cambios que revisar:
- He corregido un error que prevenía que los templates se reemplazaran correctamentes cuando se sobreescribían en una vista hijo de WidgetTablePaginatedView.  Con este cambio se evita el bug de visualización en el que se muestran los dos botones de descarga mientras se carga la tabla, esto causó que en las tablas que no incluyen el botón de descarga fuera de la tabla aparecieran sin botón. Para ello, he actualizado el valor de la propiedad downloadButton a true en la vista WidgetDeviceTable, de modo que en aquellas tablas en las que se quiera agregar el boton de descarga fuera de la tabla, se ha de indicar este parámetro como false.
Por otro lado, el botón no estaba siendo capturado correctamente para el evento de click, por lo que no funcionaba la descarga.
 -- Asegurar que los botones se muestran correctamente en todas las tablas (ya sea dentro o fuera) y que es funcional.

- He actualziado la tabla con datos en bruto de ef.hídrica de modo que ahora use la vista WidgetTable. Para ello, he añadido varias clases css para que tanto en este vertical como en los que se quiera aplicar esta tabla, se muestre igual que la tabla que se usaba anteriormente. He realizado algunos cambios en WidgetTable, para poder añadir sorporte al scroll superior de la tabla. Al estar el botón ahora dentro del bloque de la tabla, he desplazado la posición del scroll superior al interior del bloque.
 -- Probar el funcionamiento de la nueva tabla, y que los cambios no hayan afectado al de aquellas vistas que usan también usan WidgetTable.