### PR TITLE
Javiguisado/ch43111/unificar los botones de descarga

### DIFF
--- a/deps.js
+++ b/deps.js
@@ -111,6 +111,7 @@ deps.JS = [
   srcJS + 'View/widgets/WidgetWrapperBase.js',
   srcJS + 'View/widgets/WidgetTableView.deprecated.js',
   srcJS + 'View/widgets/WidgetTablePaginatedView.js',
+  srcJS + 'View/widgets/CustomDeviceRawTable.js',
 
   srcJS + 'View/widgets/WidgetCorrelation.js',
 

--- a/src/js/View/widgets/CustomDeviceRawTable.js
+++ b/src/js/View/widgets/CustomDeviceRawTable.js
@@ -94,18 +94,15 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
       if (typeof variable.format === 'function') {
         formatFN = variable.format;
       } else {
-        switch (variable.format) {
+        switch (variable.format.type) {
           case 'numeric':
-            formatFN = _this.numericFn(variable.id);
+            formatFN = _this.numericFn(variable.id, variable.format.options);
             break;
           case 'boolean':
-            formatFN = _this.booleanFn;
-            break;
-          case 'boolean2':
-            formatFN = _this.boolean2Fn;
+            formatFN = _this.booleanFn(variable.format.options);
             break;
           case 'date':
-            formatFN = _this.dateFn;
+            formatFN = _this.dateFn(variable.format.options);
             break;
         }
       }
@@ -138,13 +135,13 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
     return entityVariables;
   },
 
-  numericFn: function (id) {
+  numericFn: function (id, options) {
     var _this = this;
     var units = _this.getVariableUnits(id)
 
     return function (value) {
       if(value != Number.parseInt(value)){
-        value = App.nbf(value)
+        value = App.nbf(value, options)
       }
       return value + ( units
         ? ' ' + units
@@ -152,16 +149,25 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
     }
   },
 
-  booleanFn: function (value) {
-    return value ? __('Activa') : __('No activa');
+  booleanFn: function(format) {
+    var isTrue = __('Sí');
+    var isFalse = __('No');
+   
+    if (format && typeof format.true != 'undefined' &&  typeof format.false != 'undefined') {
+      isTrue = format.true;
+      isFalse = format.false;
+    }
+    
+    return function (value) {
+      return value ? isTrue : isFalse;
+
+    }
   },
 
-  boolean2Fn: function (value) {
-    return value ? __('Si') : __('No');
-  },
-
-  dateFn: function (value) {
-    return App.formatDateTime(value);
+  dateFn: function(format){
+    return function (value) {
+      return App.formatDateTime(value, format);
+    }
   },
 
   getVariableUnits: function (id) {

--- a/src/js/View/widgets/CustomDeviceRawTable.js
+++ b/src/js/View/widgets/CustomDeviceRawTable.js
@@ -99,7 +99,7 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
           case 'boolean':
             formatFN = _this.booleanFn;
             break;
-          case 'bolean2':
+          case 'boolean2':
             formatFN = _this.boolean2Fn;
             break;
           case 'date':

--- a/src/js/View/widgets/CustomDeviceRawTable.js
+++ b/src/js/View/widgets/CustomDeviceRawTable.js
@@ -33,6 +33,8 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
       title: __('Datos brutos'),
       dimension: 'fullWidth bgWhite custom-device-raw-table',
       timeMode: 'historic',
+      csv: true,
+      scrollTopBar:true,
       variables: []
     });
 
@@ -77,8 +79,8 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
 
   getTableSetup: function () {
     return new Backbone.Model({
-      csv: true,
-      scrollTopBar: true,
+      csv: this.options.csv,
+      scrollTopBar: this.options.scrollTopBar,
       columns_format: this.getColumnsFormat()
     });
   },

--- a/src/js/View/widgets/CustomDeviceRawTable.js
+++ b/src/js/View/widgets/CustomDeviceRawTable.js
@@ -111,10 +111,10 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
       columnsFormat[variable.id] = {
         title: variable.title,
         formatFN: formatFN
-      }
+      };
     });
 
-    return columnsFormat
+    return columnsFormat;
   },
   /**
    * Get entity's variables
@@ -133,7 +133,7 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
         return variable.config && variable.config.active;
       })
 
-    return entityVariables
+    return entityVariables;
   },
 
   numericFn: function (id) {
@@ -151,11 +151,11 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
   },
 
   booleanFn: function (value) {
-    return value ? __('Activa') : __('No activa')
+    return value ? __('Activa') : __('No activa');
   },
 
   boolean2Fn: function (value) {
-    return value ? __('Si') : __('No')
+    return value ? __('Si') : __('No');
   },
 
   dateFn: function (value) {
@@ -165,8 +165,8 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
   getVariableUnits: function (id) {
     var variable = this.getEntityVariables().find(function (obj) {
       return obj.id === id;
-    })
+    });
 
-    return variable.units
+    return variable.units;
   }
 })

--- a/src/js/View/widgets/CustomDeviceRawTable.js
+++ b/src/js/View/widgets/CustomDeviceRawTable.js
@@ -1,0 +1,165 @@
+// Copyright 2017 Telefónica Digital España S.L.
+//
+// PROJECT: urbo-telefonica
+//
+// This software and / or computer program has been developed by
+// Telefónica Digital España S.L. (hereinafter Telefónica Digital) and is protected as
+// copyright by the applicable legislation on intellectual property.
+//
+// It belongs to Telefónica Digital, and / or its licensors, the exclusive rights of
+// reproduction, distribution, public communication and transformation, and any economic
+// right on it, all without prejudice of the moral rights of the authors mentioned above.
+// It is expressly forbidden to decompile, disassemble, reverse engineer, sublicense or
+// otherwise transmit by any means, translate or create derivative works of the software and
+// / or computer programs, and perform with respect to all or part of such programs, any
+// type of exploitation.
+//
+// Any use of all or part of the software and / or computer program will require the
+// express written consent of Telefónica Digital. In all cases, it will be necessary to make
+// an express reference to Telefónica Digital ownership in the software and / or computer
+// program.
+//
+// Non-fulfillment of the provisions set forth herein and, in general, any violation of
+// the peaceful possession and ownership of these rights will be prosecuted by the means
+// provided in both Spanish and international law. Telefónica Digital reserves any civil or
+// criminal actions it may exercise to protect its rights.
+
+'use strict';
+
+App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
+
+  initialize: function (options) {
+    options = _.defaults(options, {
+      title: __('Datos brutos'),
+      dimension: 'fullWidth bgWhite custom-device-raw-table',
+      timeMode: 'historic',
+      variables: []
+    });
+
+    //this._variables = options.variables;
+
+    _.bindAll(this, 'parseCollectionTable');
+
+    // Init parent class
+    App.View.Widgets.Base.prototype.initialize.call(this, options);
+
+    var rawTable = new App.View.Widgets.Table({
+      model: this.getTableSetup(),
+      data: this.getTableCollection(),
+      listenContext: true,
+    });
+
+    // Add Table to the "widget content"
+    this.subviews.push(rawTable);
+  },
+
+  getTableCollection: function () {
+    var tableCollection = new App.Collection.DeviceRaw(null, {
+      scope: this.options.scope,
+      entity: this.options.entity,
+      device: this.options.device,
+      variables: _.pluck(this.getEntityVariables(), 'id')
+    });
+
+    tableCollection.parse = this.parseCollectionTable;
+
+    return tableCollection;
+  },
+
+  parseCollectionTable: function (response) {
+    //parse response with own variable name as key
+    return _.map(response, function (row) {
+      var parsedRow = {}
+      _.extend(parsedRow, { date: row.time }, row.data)
+      return parsedRow
+    });
+  },
+
+  getTableSetup: function () {
+    return new Backbone.Model({
+      csv: true,
+      scrollTopBar: true,
+      columns_format: this.getColumnsFormat()
+    });
+  },
+
+  getColumnsFormat: function () {
+    var _this = this
+    var columnsFormat = {}
+    _.map(this.options.variables, function (variable) {
+      var formatFN = null;
+
+      if (typeof variable.format === 'function') {
+        formatFN = variable.format;
+      } else {
+        switch (variable.format) {
+          case 'numeric':
+            formatFN = _this.numericFn(variable.id);
+            break;
+          case 'boolean':
+            formatFN = _this.booleanFn;
+            break;
+          case 'date':
+            formatFN = _this.dateFn
+            break;
+        }
+      }
+
+      columnsFormat[variable.id] = {
+        title: variable.title,
+        formatFN: formatFN
+      }
+    });
+
+    return columnsFormat
+  },
+  /**
+   * Get entity's variables
+   *
+   * @return {Array} - variables
+   */
+  getEntityVariables: function () {
+    // All entity variables filtered by
+    // "config.active" (activated) and order
+    var entityVariables = App.Utils.toDeepJSON(
+      App.mv()
+        .getEntity(this.options.entity)
+        .get('variables')
+    )
+      .filter(function (variable) {
+        return variable.config && variable.config.active;
+      })
+
+    return entityVariables
+  },
+
+  numericFn: function (id) {
+    var _this = this;
+    var units = _this.getVariableUnits(id)
+
+    return function (value) {
+      if(value != Number.parseInt(value)){
+        value = App.nbf(value)
+      }
+      return value + ( units
+        ? ' ' + units
+        : '' );
+    }
+  },
+
+  booleanFn: function (value) {
+    return value ? __('Activa') : __('No activa')
+  },
+
+  dateFn: function (value) {
+    return App.formatDateTime(value);
+  },
+
+  getVariableUnits: function (id) {
+    var variable = this.getEntityVariables().find(function (obj) {
+      return obj.id === id;
+    })
+
+    return variable.units
+  }
+})

--- a/src/js/View/widgets/CustomDeviceRawTable.js
+++ b/src/js/View/widgets/CustomDeviceRawTable.js
@@ -99,8 +99,11 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
           case 'boolean':
             formatFN = _this.booleanFn;
             break;
+          case 'bolean2':
+            formatFN = _this.boolean2Fn;
+            break;
           case 'date':
-            formatFN = _this.dateFn
+            formatFN = _this.dateFn;
             break;
         }
       }
@@ -149,6 +152,10 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
 
   booleanFn: function (value) {
     return value ? __('Activa') : __('No activa')
+  },
+
+  boolean2Fn: function (value) {
+    return value ? __('Si') : __('No')
   },
 
   dateFn: function (value) {

--- a/src/js/View/widgets/CustomDeviceRawTable.js
+++ b/src/js/View/widgets/CustomDeviceRawTable.js
@@ -86,8 +86,8 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
   },
 
   getColumnsFormat: function () {
-    var _this = this
-    var columnsFormat = {}
+    var _this = this;
+    var columnsFormat = {};
     _.map(this.options.variables, function (variable) {
       var formatFN = null;
 
@@ -137,11 +137,11 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
 
   numericFn: function (id, options) {
     var _this = this;
-    var units = _this.getVariableUnits(id)
+    var units = _this.getVariableUnits(id);
 
     return function (value) {
       if(value != Number.parseInt(value)){
-        value = App.nbf(value, options)
+        value = App.nbf(value, options);
       }
       return value + ( units
         ? ' ' + units


### PR DESCRIPTION
- He añadido una vista nueva para utilizar a la hora de crear tablas de datos brutos de dispositivos que facilita el manejo de WidgetTable.
- De momento solo se está usando en eff.hidrica, fuegos y cattle. El objetivo es generalziar esta tabla para todos los verticales y tener un lugar donde realziar las modificaciones pertinentes que afecten a todas. 
- Está hecha de forma que permita customizar el formato y el orden de las columnas.
- En los casos en los que la capacidad de customización no sea suficiente y sea necesario sobreescribir algún método podremos extenderla dentro de la propia vertical.