### PR TITLE
fix table csv download

### DIFF
--- a/src/js/View/widgets/CustomDeviceRawTable.js
+++ b/src/js/View/widgets/CustomDeviceRawTable.js
@@ -54,6 +54,7 @@ App.View.Widgets.CustomDeviceRawTable = App.View.Widgets.Base.extend({
       scope: this.options.scope,
       entity: this.options.entity,
       device: this.options.device,
+      format:'csv',
       variables: _.pluck(this.getEntityVariables(), 'id')
     });
 

--- a/src/js/View/widgets/WidgetTable.js
+++ b/src/js/View/widgets/WidgetTable.js
@@ -98,11 +98,17 @@ App.View.Widgets.Table = Backbone.View.extend({
 
   _downloadCsv: function () {
     this._tableToCsv.options = App.Utils.toDeepJSON(this.collection.options);
-    this._tableToCsv.options.format = 'csv';
+    //Just avoiding any breaking change
+    if (this._tableToCsv.options.format === 'csv'){
+      //Make sure format is added inside data object for new table widgets
+      this._tableToCsv.options.data.format = 'csv';
+    } else {
+      //Old table widgets
+      this._tableToCsv.options.format = 'csv';
+    }
 
     this._tableToCsv.options.reset = false;
     this._tableToCsv.options.dataType = 'text'
-
     // this._tableToCsv.fetch({'reset':false,'dataType':'text'})
     this._tableToCsv.fetch(this._tableToCsv.options);
   },


### PR DESCRIPTION
- Se estaba enviando la opcion de format: 'csv' fuera del objeto data, por lo que no se estaba realizando bien la petición, no se si debido a algun cambio reciente o nunca funcionó de tal manera. He dejado la antigua opción de WidgetTable intacta por si algun widget antiguo aún funciona de esa forma.