### PR TITLE
Fix graph variable labels height

### DIFF
--- a/src/js/template/widgets/widget_multiVariable_list_variables.html
+++ b/src/js/template/widgets/widget_multiVariable_list_variables.html
@@ -20,23 +20,21 @@
       <span class="icon">
         <img class="iconSelected"
              src="<%=App.getPictureAgg(currentAggs[dato.realKey])%>" />
-      </span>
-    <div class="varsel">
-      <ul data-id="<%=dato.realKey%>">
-        <%_.each(dato.aggs,function(v){%>
-        <li data-agg="<%=v%>"
-            class="<%=v == currentAggs[dato.realKey].toUpperCase() ? 'selected':''%>">
-          <span class="icon">
-            <img class="iconPopup"
-                 src="<%=App.getPictureAgg(v)%>" />
-          </span>
-          <span class="text last">
-            <%=App.getAggStr(v)%>
-          </span>
-        </li>
-        <%})%>
-      </ul>
-    </div>
+      </span><div class="varsel">
+        <ul data-id="<%=dato.realKey%>">
+          <%_.each(dato.aggs,function(v){%>
+          <li data-agg="<%=v%>" class="<%=v == currentAggs[dato.realKey].toUpperCase() ? 'selected':''%>">
+            <span class="icon">
+              <img class="iconPopup"
+                  src="<%=App.getPictureAgg(v)%>" />
+            </span>
+            <span class="text last">
+              <%=App.getAggStr(v)%>
+            </span>
+          </li>
+          <%})%>
+        </ul>
+      </div>
     </a>
     <% } %>
   </div>


### PR DESCRIPTION
Extra line break ("\n") inside <a></a> was generating empty spaces and forcing wrong height inside .btnLabel in Firefox under some circumstances