### PR TITLE
Modificando comportamiento del buscador (mapas)

### DIFF
--- a/src/js/View/Map/MapSearchView.js
+++ b/src/js/View/Map/MapSearchView.js
@@ -77,11 +77,11 @@ App.View.MapSearch = Backbone.View.extend({
       }
     }
 
-    this._collection.fetch({
-      reset: true
-    });
+    if (this._collection.options.term.length) {
+      this._collection.fetch({
+        reset: true
+      });
 
-    if (this._collection.options.term.length > 0) {
       this.$('#search_map').addClass('searching');
       this.$('.loading').remove();
       this.$('#search_map').append(App.circleLoading());
@@ -92,11 +92,16 @@ App.View.MapSearch = Backbone.View.extend({
 
   _collectionReset: function () {
     this.$('.loading').remove();
-    this.$('ul').html(this._template_list({ 'elements': this._collection.toJSON() }));
-    if (this._collection.toJSON().length > 0)
+
+    if (this._collection.toJSON().length > 0
+      && this._collection.options.term.length) {
       this.$('ul').addClass('active');
-    else
+      this.$('ul').html(this._template_list({
+        elements: this._collection.toJSON() 
+      }));
+    } else {
       this.$('ul').removeClass('active');
+    }
   },
 
   _selectTerm: function (e) {


### PR DESCRIPTION
Si el campo de búsqueda esta vacío, no debe mostrar nada en el listado de elementos encontrados