### PR TITLE
Modificaciones tras QA del día 24 de septiembre 2019

### DIFF
--- a/src/js/View/DateView.js
+++ b/src/js/View/DateView.js
@@ -207,6 +207,14 @@ App.View.Date = Backbone.View.extend({
       || moment(this.options.maxDate).isAfter(this.options.model.get('finish'))
         ? this.options.model.get('finish').toDate()
         : this.options.maxDate;
+    // The difference between start and finish is higher that "maxRange"
+    var diffTime = moment(dateFinish).diff(dateStart, 'days');
+
+    if (diffTime > this.options.maxRange.asDays()) {
+      dateFinish = this.options.maxRange.asDays() >= 365
+        ? moment(dateStart).clone().add(this.options.maxRange.asYears(), 'years').toDate()
+        : moment(dateStart).clone().add(this.options.maxRange.asDays(), 'days').toDate();
+    }
 
     try {
       this.$('.date.start').datepicker('setDate', dateStart);

--- a/src/js/View/widgets/Charts/MultiChart.js
+++ b/src/js/View/widgets/Charts/MultiChart.js
@@ -108,9 +108,6 @@ App.View.Widgets.Charts.MultiChart = App.View.Widgets.Charts.Base.extend({
     // Get max value for each axis and adjust domain
     // var domains = this.options.get('yAxisDomain') ? this.options.get('yAxisDomain') : [[0,1],[0,1]];
     var domains =[[0,1],[0,1]];
-    // Clear null from array
-    if(min[0]) min[0] = min[0].filter(Boolean);
-    if(min[1]) min[1] = min[1].filter(Boolean);
     var minAxis1 = Math.min.apply(null, min[0]),
         minAxis2 = Math.min.apply(null, min[1]);
     var maxAxis1 = Math.max.apply(null, max[0]),


### PR DESCRIPTION
- Cuando se inicia "dateview" se comprueba desde la fecha "desde" que el rango de las fechas no excede el máximo del panel

- Modificada "App.View.Widgets.Charts.MultiChart" ya que elminaba los valores NULL (Evolución del consumo eléctrico y Consumo eléctrico en 24h)